### PR TITLE
settings fix for options

### DIFF
--- a/src/Factory/IbmiToolkitFactory.php
+++ b/src/Factory/IbmiToolkitFactory.php
@@ -35,7 +35,7 @@ final class IbmiToolkitFactory implements FactoryInterface
             '0'
         );
 
-        $toolkit->setOptions($toolkitConfig);
+        $toolkit->setOptions($toolkitConfig['system']);
 
         return $toolkit;
     }


### PR DESCRIPTION
The options only work when you use the settings array key